### PR TITLE
Implement Dockerfiles for backend and frontend

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -18,8 +18,8 @@ Este documento describe las épicas, objetivos y tareas para construir la aplica
 **Objetivo:** preparar la ejecución de los servicios mediante contenedores.
 
 **Tareas principales:**
-2.1 Crear `Dockerfile` para el backend en Python.
-2.2 Crear `Dockerfile` para el frontend (React Native para web o similar).
+ - [x] 2.1 Crear `Dockerfile` para el backend en Python.
+ - [x] 2.2 Crear `Dockerfile` para el frontend (React Native para web o similar).
 2.3 Configurar repositorio ECR y subir imágenes.
 2.4 Definir un clúster ECS o EKS y desplegar los contenedores.
 2.5 Automatizar el despliegue desde la canalización de CI/CD.

--- a/README.md
+++ b/README.md
@@ -30,3 +30,19 @@ terraform plan
 ```
 
 Tambien se incluye un workflow de GitHub Actions que valida la configuracion en cada _pull request_.
+
+## Contenedores Docker
+
+Existen dos directorios principales para crear las imágenes de la aplicación:
+
+- `backend`: servicio FastAPI que expone la API principal.
+- `frontend`: aplicación React que consumirá el backend.
+
+Para construir cada imagen se incluyen Dockerfiles básicos. Ejemplo de uso:
+
+```bash
+cd backend
+docker build -t friends-money-backend .
+cd ../frontend
+docker build -t friends-money-frontend .
+```

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY main.py ./
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/")
+def read_root():
+    return {"hello": "world"}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json ./
+RUN npm install --omit=dev
+COPY . .
+CMD ["npm", "start"]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "friends-money-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "scripts": {
+    "start": "echo 'placeholder'"
+  }
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -5,8 +5,8 @@ resource "aws_iam_role" "lambda_exec" {
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [{
-      Action = "sts:AssumeRole"
-      Effect = "Allow"
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
       Principal = { Service = "lambda.amazonaws.com" }
     }]
   })


### PR DESCRIPTION
## Summary
- add FastAPI backend with Dockerfile
- create placeholder React frontend with Dockerfile
- document how to build the new Docker images in README
- mark Dockerfile tasks as completed in PLAN

## Testing
- `terraform fmt -check -recursive`
- `terraform -chdir=terraform init -backend=false`
- `terraform -chdir=terraform validate`
- `pre-commit run --files PLAN.md README.md backend/Dockerfile backend/main.py backend/requirements.txt frontend/Dockerfile frontend/package.json terraform/main.tf`

------
https://chatgpt.com/codex/tasks/task_e_68542540fcf083339e335d292510f56e