### PR TITLE
Implement basic authentication API

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,7 +1,117 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+from pydantic import BaseModel
+from sqlalchemy import Column, Integer, String, create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker, Session
+
+DATABASE_URL = "sqlite:///./app.db"
+SECRET_KEY = "change-me"
+ALGORITHM = "HS256"
+
+engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String, unique=True, index=True)
+    hashed_password = Column(String)
+
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+
+
+def create_database() -> None:
+    """Ensure required tables exist."""
+    Base.metadata.create_all(bind=engine)
+
+
+def get_db() -> Session:
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def get_password_hash(password: str) -> str:
+    return pwd_context.hash(password)
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def authenticate_user(db: Session, username: str, password: str):
+    user = db.query(User).filter(User.username == username).first()
+    if not user:
+        return False
+    if not verify_password(password, user.hashed_password):
+        return False
+    return user
+
+
+def create_access_token(data: dict) -> str:
+    return jwt.encode(data, SECRET_KEY, algorithm=ALGORITHM)
+
+
+class UserCreate(BaseModel):
+    username: str
+    password: str
+
+
+class Token(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+
 
 app = FastAPI()
+
+
+@app.on_event("startup")
+def startup() -> None:
+    create_database()
+
 
 @app.get("/")
 def read_root():
     return {"hello": "world"}
+
+
+@app.post("/users/", response_model=dict)
+def create_user(user: UserCreate, db: Session = Depends(get_db)):
+    db_user = db.query(User).filter(User.username == user.username).first()
+    if db_user:
+        raise HTTPException(status_code=400, detail="Username already registered")
+    user_obj = User(username=user.username, hashed_password=get_password_hash(user.password))
+    db.add(user_obj)
+    db.commit()
+    db.refresh(user_obj)
+    return {"id": user_obj.id, "username": user_obj.username}
+
+
+@app.post("/token", response_model=Token)
+def login(form_data: OAuth2PasswordRequestForm = Depends(), db: Session = Depends(get_db)):
+    user = authenticate_user(db, form_data.username, form_data.password)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Incorrect username or password")
+    token = create_access_token({"sub": user.username})
+    return Token(access_token=token)
+
+
+@app.get("/me")
+def read_users_me(token: str = Depends(oauth2_scheme)):
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        username: str | None = payload.get("sub")
+        if username is None:
+            raise HTTPException(status_code=401, detail="Invalid token")
+    except JWTError:
+        raise HTTPException(status_code=401, detail="Invalid token")
+    return {"username": username}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,2 +1,7 @@
 fastapi
 uvicorn
+sqlalchemy
+passlib[bcrypt]
+python-jose[cryptography]
+httpx<0.26
+python-multipart

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,52 @@
+import os
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from main import app, Base, get_db
+
+SQLALCHEMY_DATABASE_URL = 'sqlite:///:memory:'
+
+from sqlalchemy.pool import StaticPool
+
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL,
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base.metadata.create_all(bind=engine)
+
+# override get_db dependency
+
+def override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+app.dependency_overrides[get_db] = override_get_db
+client = TestClient(app)
+
+
+def test_register_and_login():
+    Base.metadata.create_all(bind=engine)
+
+    response = client.post('/users/', json={'username': 'alice', 'password': 'secret'})
+    assert response.status_code == 200
+    data = response.json()
+    assert data['username'] == 'alice'
+
+    response = client.post('/token', data={'username': 'alice', 'password': 'secret'})
+    assert response.status_code == 200
+    token = response.json()['access_token']
+    assert token
+
+    response = client.get('/me', headers={'Authorization': f'Bearer {token}'})
+    assert response.status_code == 200
+    assert response.json()['username'] == 'alice'


### PR DESCRIPTION
## Summary
- add SQLAlchemy models and JWT-based auth in FastAPI backend
- update backend requirements with needed packages
- add tests for registration and login

## Testing
- `pre-commit run --files backend/main.py backend/requirements.txt backend/tests/test_auth.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685432aa3a848333a7dac1bba917f843